### PR TITLE
Removed /api prefix from endpoints, and add /users prefix to auth

### DIFF
--- a/documentation/test-plan.md
+++ b/documentation/test-plan.md
@@ -2,12 +2,12 @@
 
 ## Changelog
 
-| Version | Change Date | By                                                     | Description                                            |
-| ------- | ----------- | ------------------------------------------------------ | ------------------------------------------------------ |
-| 0.1     | 10/02/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Created initial testing plan template in markdown.     |
-| 0.2     | 10/03/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Wrote initial draft for test plan.                     |
-| 0.3     | 10/04/2023  | [Barbara Guzman Romero](https://github.com/BarbzCodez) | Fixed the tables, added Victoria back as a QA Analyst  |
-| 0.4     | 10/08/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Added final unit tests and added integration tests     |
+| Version | Change Date | By                                                     | Description                                           |
+| ------- | ----------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| 0.1     | 10/02/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Created initial testing plan template in markdown.    |
+| 0.2     | 10/03/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Wrote initial draft for test plan.                    |
+| 0.3     | 10/04/2023  | [Barbara Guzman Romero](https://github.com/BarbzCodez) | Fixed the tables, added Victoria back as a QA Analyst |
+| 0.4     | 10/08/2023  | [Daniel La Rocque](https://github.com/dlarocque)       | Added final unit tests and added integration tests    |
 
 ## 1. Introduction
 
@@ -17,22 +17,22 @@ This test plan covers unit, integration, acceptance, regression, and load testin
 
 ### 1.2 Roles and Responsibilities
 
-| Name                  | UMNet ID  | GitHub username | Role                                                |
-| --------------------- | --------- | --------------- | --------------------------------------------------- |
-| Daniel La Rocque      | larocq17  | dlarocque       | Backend Developer, Test Manager, Security Analyst   |
-| Victoria Kogan        | koganv    | VictoriaKGN     | Frontend Developer, QA Analyst                      |
-| Mark Lysack           | lysackm   | lysackm         | Backend Developer, DevOps Developer                 |
-| Barbara Guzman Romero | guzmanrb  | BarbzCodez      | Frontend Developer, QA Analyst                      |
-| Ethan Ducharme        | duchar36  | DucharmeEthan   | Backend Developer, Database Administrator           |
+| Name                  | UMNet ID | GitHub username | Role                                              |
+| --------------------- | -------- | --------------- | ------------------------------------------------- |
+| Daniel La Rocque      | larocq17 | dlarocque       | Backend Developer, Test Manager, Security Analyst |
+| Victoria Kogan        | koganv   | VictoriaKGN     | Frontend Developer, QA Analyst                    |
+| Mark Lysack           | lysackm  | lysackm         | Backend Developer, DevOps Developer               |
+| Barbara Guzman Romero | guzmanrb | BarbzCodez      | Frontend Developer, QA Analyst                    |
+| Ethan Ducharme        | duchar36 | DucharmeEthan   | Backend Developer, Database Administrator         |
 
 ### 1.3 Role definitions
 
-- **Backend Developer**:  Responsible for implementing and testing backend functionality.
+- **Backend Developer**: Responsible for implementing and testing backend functionality.
 - **Frontend Developer**: Tasked with implementing and testing user interface and experience.
 - **Test Manager**: Coordinates backend testing, ensuring coverage and criteria are met.
 - **QA Analyst**: Responsible for the overall quality of the application, involved in all types of testing.
 - **Security Analyst**: Ensures the application meets all security guidelines and passes security testing.
-- **Database Administrator**:  Responsible for database setup, maintenance, and data integrity.
+- **Database Administrator**: Responsible for database setup, maintenance, and data integrity.
 - **DevOps Developer**: Manages CI/CD pipelines, deployments, and environment configurations.
 
 ## 2. Test Methodology
@@ -48,73 +48,73 @@ This test plan covers unit, integration, acceptance, regression, and load testin
 ### Unit Tests
 
 1. User Management
-   1. Return `201 Created` upon POST request to `/api/auth/register` with valid payload.
-   2. Return `400 Bad Request` upon POST request to `/api/auth/register` with an already used username.
-   3. Return `200 OK` and a JWT upon POST to `/api/auth/login` with correct credentials.
-   4. Return `400 Bad Request` upon POST to `/api/auth/login` with incorrect credentials.
-   5. Return `200 OK` upon POST to `/api/auth/reset-password` with the correct security answer.
-   6. Return `400 Bad Request` upon POST to `/api/auth/reset-password` with the incorrect security answer.
-   7. Return `400 Bad Request` upon POST to `/api/auth/reset-password` with a missing payload.
-   8. Return `200 OK` upon PUT to `/api/account` with valid new user data.
-   9. Return `400 Bad Request` upon PUT to `/api/account` with a new username that already exists.
-   10. Return `200 OK` upon DELETE to `/api/account` from authenticated session.
+   1. Return `201 Created` upon POST request to `/auth/register` with valid payload.
+   2. Return `400 Bad Request` upon POST request to `/auth/register` with an already used username.
+   3. Return `200 OK` and a JWT upon POST to `/auth/login` with correct credentials.
+   4. Return `400 Bad Request` upon POST to `/auth/login` with incorrect credentials.
+   5. Return `200 OK` upon POST to `/auth/reset-password` with the correct security answer.
+   6. Return `400 Bad Request` upon POST to `/auth/reset-password` with the incorrect security answer.
+   7. Return `400 Bad Request` upon POST to `/auth/reset-password` with a missing payload.
+   8. Return `200 OK` upon PUT to `/account` with valid new user data.
+   9. Return `400 Bad Request` upon PUT to `/account` with a new username that already exists.
+   10. Return `200 OK` upon DELETE to `/account` from authenticated session.
 2. Expense Entry and History
-   1. Return `201 Created` upon PUT to `/api/expenses` with a valid new expense.
-   2. Return `200 OK` upon DELETE to `/api/expenses/:id` with valid expense ID.
-   3. Return `200 OK` upon PATCH to `/api/expenses/:id` with valid updates.
-   4. Return `200 OK` and correct expenses upon GET to `/api/expenses`.
-   5. Return `200 OK` and correct expense upon GET to `/api/expenses/:id` with a valid expense ID.
-   6. Return `400 Bad Request` upon POST to `/api/expenses/:id` with an invalid payload.
-   7. Return `400 Bad Request` upon POST to `/api/expenses/:id` with an invalid expense value.
-   8. Return `404 Not Found` upon DELETE to `/api/expenses/:id` with a non-existent expense ID.
-   9. Return `404 Not Found` upon PATCH to `/api/expenses/:id` with a non-existent expense ID.
-   10. Return `400 Bad Request` upon PATCH to `/api/expenses/:id` with an invalid expense.
+   1. Return `201 Created` upon PUT to `/expenses` with a valid new expense.
+   2. Return `200 OK` upon DELETE to `/expenses/:id` with valid expense ID.
+   3. Return `200 OK` upon PATCH to `/expenses/:id` with valid updates.
+   4. Return `200 OK` and correct expenses upon GET to `/expenses`.
+   5. Return `200 OK` and correct expense upon GET to `/expenses/:id` with a valid expense ID.
+   6. Return `400 Bad Request` upon POST to `/expenses/:id` with an invalid payload.
+   7. Return `400 Bad Request` upon POST to `/expenses/:id` with an invalid expense value.
+   8. Return `404 Not Found` upon DELETE to `/expenses/:id` with a non-existent expense ID.
+   9. Return `404 Not Found` upon PATCH to `/expenses/:id` with a non-existent expense ID.
+   10. Return `400 Bad Request` upon PATCH to `/expenses/:id` with an invalid expense.
 3. Budget Management
-   1. Return `201 Created` upon POST to `/api/budgets` with valid payload for setting a budget.
-   2. Return `200 OK` upon PUT to `/api/budgets/:id` with valid budget.
-   3. Return `200 OK` upon DELETE to `/api/budgets/:id` with a valid budget ID.
-   4. Return `200 OK` and all the correct budgets upon GET to `/api/budgets` to retrieve all set budgets.
-   5. Return `200 OK` and the correct budget upon GET to `/api/budget/:id` to retrieve a specific budget.
-   6. Return `400 Bad Request` upon POST to `/api/budgets` with invalid payload.
-   7. Return `404 Not Found` upon DELETE to `/api/budgets/:id` with a budget ID that does not exist.
-   8. Return `404 Not Found` upon PUT to `/api/budgets/:id` with an invalid payload.
-   9. Return `400 Bad Request` upon GET to `/api/budgets/:id` with a budget ID that does not exist.
-   10. Return `400 Bad Request` upon POST to `/api/budgets` with an negative budget amount.
+   1. Return `201 Created` upon POST to `/budgets` with valid payload for setting a budget.
+   2. Return `200 OK` upon PUT to `/budgets/:id` with valid budget.
+   3. Return `200 OK` upon DELETE to `/budgets/:id` with a valid budget ID.
+   4. Return `200 OK` and all the correct budgets upon GET to `/budgets` to retrieve all set budgets.
+   5. Return `200 OK` and the correct budget upon GET to `/budget/:id` to retrieve a specific budget.
+   6. Return `400 Bad Request` upon POST to `/budgets` with invalid payload.
+   7. Return `404 Not Found` upon DELETE to `/budgets/:id` with a budget ID that does not exist.
+   8. Return `404 Not Found` upon PUT to `/budgets/:id` with an invalid payload.
+   9. Return `400 Bad Request` upon GET to `/budgets/:id` with a budget ID that does not exist.
+   10. Return `400 Bad Request` upon POST to `/budgets` with an negative budget amount.
 4. Expense Analytics
-   1. Return `200 OK` and average amount spent per day for a month upon GET to `/api/analytics/average-daily/` with a valid year and month.
-   2. Return `400 Bad Request` upon GET to `/api/analytics/average-daily` for a month in the future.
-   3. Return `400 Bad Request` upon GET to `/api/analytics/average-daily` with invalid date formats.
-   4. Return `200 OK` and average amount spent per day for a month for a category upon GET to `/api/analytics/average-daily/` with a valid year, month, and category.
-   5. Return `400 Bad Request` upon GET to `/api/analytics/average-daily` for a category that does not exist.
-   6. Return `400 Bad Request` upon GET to `/api/analytics/average-daily` with a missing payload.
-   7. Return `200 OK` and average amount spent per month since the first month upon GET to `/api/analytics/average-monthly`.
-   8. Return `200 OK` and total amount spent for each category upon GET to `/api/analytics/amount/`.
-   9. Return `200 OK` and total amount spent for a specific category upon GET to `/api/analytics/amount` with an existing category.
-   10. Return `400 Bad Request` upon GET to `/api/analytics/amount` with a category that does not exist.
+   1. Return `200 OK` and average amount spent per day for a month upon GET to `/analytics/average-daily/` with a valid year and month.
+   2. Return `400 Bad Request` upon GET to `/analytics/average-daily` for a month in the future.
+   3. Return `400 Bad Request` upon GET to `/analytics/average-daily` with invalid date formats.
+   4. Return `200 OK` and average amount spent per day for a month for a category upon GET to `/analytics/average-daily/` with a valid year, month, and category.
+   5. Return `400 Bad Request` upon GET to `/analytics/average-daily` for a category that does not exist.
+   6. Return `400 Bad Request` upon GET to `/analytics/average-daily` with a missing payload.
+   7. Return `200 OK` and average amount spent per month since the first month upon GET to `/analytics/average-monthly`.
+   8. Return `200 OK` and total amount spent for each category upon GET to `/analytics/amount/`.
+   9. Return `200 OK` and total amount spent for a specific category upon GET to `/analytics/amount` with an existing category.
+   10. Return `400 Bad Request` upon GET to `/analytics/amount` with a category that does not exist.
 5. Group Expense Splitting
-   1. Return `201 Created` upon POST to `/api/group-expenses` with valid amount, breakdown, and users that exist.
-   2. Return `200 OK` and correct group expense data upon GET to `/api/group-expenses/:id` with an existing group expense ID.
-   3. Return `200 OK` upon PUT to `/api/group-expenses/:id/paid` to mark a group expense as paid.
-   4. Return `200 OK` upon GET to `/api/group-expenses/:id/paid` to retrieve status of 'paid' by all other users.
-   5. Return `200 OK` and all group expense data upon GET to `/api/group-expenses`.
-   6. Return `200 OK` upon PUT to `/api/group-expenses/:id/opt-out` to opt out of a group expense.
-   7. Return `200 OK` upon DELETE to `/api/group-expenses/:id` to delete a group expense, as the creator of the expense with a valid group expense ID.
-   8. Return `400 Bad Request` upon POST to `/api/group-expenses` with a negative expense value.
-   9. Return `400 Bad Request` upon POST to `/api/group-expenses` including a username that does not exist.
-   10. Return `400 Bad Request` upon GET to `/api/group-expenses/:id` with a group expense ID that does not exist.
+   1. Return `201 Created` upon POST to `/group-expenses` with valid amount, breakdown, and users that exist.
+   2. Return `200 OK` and correct group expense data upon GET to `/group-expenses/:id` with an existing group expense ID.
+   3. Return `200 OK` upon PUT to `/group-expenses/:id/paid` to mark a group expense as paid.
+   4. Return `200 OK` upon GET to `/group-expenses/:id/paid` to retrieve status of 'paid' by all other users.
+   5. Return `200 OK` and all group expense data upon GET to `/group-expenses`.
+   6. Return `200 OK` upon PUT to `/group-expenses/:id/opt-out` to opt out of a group expense.
+   7. Return `200 OK` upon DELETE to `/group-expenses/:id` to delete a group expense, as the creator of the expense with a valid group expense ID.
+   8. Return `400 Bad Request` upon POST to `/group-expenses` with a negative expense value.
+   9. Return `400 Bad Request` upon POST to `/group-expenses` including a username that does not exist.
+   10. Return `400 Bad Request` upon GET to `/group-expenses/:id` with a group expense ID that does not exist.
 
 ### Integration Tests
 
-1. After creating a new user with a POST request to `/api/auth/register`, the new user data is found in the database with the hashed security answer and password.
-2. After a client obtains JWT from signing in via POST to `/api/auth/login`, the JWT can be used to make request to an authorized route.
-3. After a client sends the correct security answer via POST to `/api/auth/reset-password`, their password is successfully hashed and updated in the database.
-4. After a client sends new user data via POST to `/api/account/`, their new user data is updated in the database.
-5. After an expense is created via POST to `/api/expenses`, the user can then fetch the expense they just created via GET to `/api/expenses/:id`.
-6. After an expense is deleted via POST to `/api/expenses/:id`, the expense no longer exists in the database, and they can no longer fetch the expense they just deleted via GET to `/api/expenses/:id`.
-7. After an expense is created via POST to `/api/expenses`, it correctly contributes to the current months average daily spending retrieved from `/api/analytics/average-daily`.
-8. After a user deletes their account via DELETE to `/api/account`, all data in the database associated with their user is deleted, except for group expenses.
-9. After a user creates a group expense via POST to `/api/group-expenses`, and marks it as paid via `/api/group-expenses/:id`, the expense is added to their expenses in the database.
-10. After a user creates a budget via POST to `/api/budgets`, the budget exists in the database and is associated with their account.
+1. After creating a new user with a POST request to `/auth/register`, the new user data is found in the database with the hashed security answer and password.
+2. After a client obtains JWT from signing in via POST to `/auth/login`, the JWT can be used to make request to an authorized route.
+3. After a client sends the correct security answer via POST to `/auth/reset-password`, their password is successfully hashed and updated in the database.
+4. After a client sends new user data via POST to `/account/`, their new user data is updated in the database.
+5. After an expense is created via POST to `/expenses`, the user can then fetch the expense they just created via GET to `/expenses/:id`.
+6. After an expense is deleted via POST to `/expenses/:id`, the expense no longer exists in the database, and they can no longer fetch the expense they just deleted via GET to `/expenses/:id`.
+7. After an expense is created via POST to `/expenses`, it correctly contributes to the current months average daily spending retrieved from `/analytics/average-daily`.
+8. After a user deletes their account via DELETE to `/account`, all data in the database associated with their user is deleted, except for group expenses.
+9. After a user creates a group expense via POST to `/group-expenses`, and marks it as paid via `/group-expenses/:id`, the expense is added to their expenses in the database.
+10. After a user creates a budget via POST to `/budgets`, the budget exists in the database and is associated with their account.
 
 ### 2.2 Test Completeness
 
@@ -152,10 +152,10 @@ This test plan covers unit, integration, acceptance, regression, and load testin
 
 Make a mention of any terms or acronyms used in the project
 
-| Term/Acronym | Definition                                       |
-| ------------ | ------------------------------------------------ |
-| API          | Application Program Interface                    |
-| AUT          | Application Under Test                           |
-| QA           | Quality Assurance                                |
-| CI/CD        | Continuous Integration / Continuous Deployment   |
-| JWT          | JSON Web Token                                   |
+| Term/Acronym | Definition                                     |
+| ------------ | ---------------------------------------------- |
+| API          | Application Program Interface                  |
+| AUT          | Application Under Test                         |
+| QA           | Quality Assurance                              |
+| CI/CD        | Continuous Integration / Continuous Deployment |
+| JWT          | JSON Web Token                                 |

--- a/documentation/test-plan.md
+++ b/documentation/test-plan.md
@@ -48,16 +48,16 @@ This test plan covers unit, integration, acceptance, regression, and load testin
 ### Unit Tests
 
 1. User Management
-   1. Return `201 Created` upon POST request to `/auth/register` with valid payload.
-   2. Return `400 Bad Request` upon POST request to `/auth/register` with an already used username.
-   3. Return `200 OK` and a JWT upon POST to `/auth/login` with correct credentials.
-   4. Return `400 Bad Request` upon POST to `/auth/login` with incorrect credentials.
-   5. Return `200 OK` upon POST to `/auth/reset-password` with the correct security answer.
-   6. Return `400 Bad Request` upon POST to `/auth/reset-password` with the incorrect security answer.
-   7. Return `400 Bad Request` upon POST to `/auth/reset-password` with a missing payload.
-   8. Return `200 OK` upon PUT to `/account` with valid new user data.
-   9. Return `400 Bad Request` upon PUT to `/account` with a new username that already exists.
-   10. Return `200 OK` upon DELETE to `/account` from authenticated session.
+   1. Return `201 Created` upon POST request to `/users/register` with valid payload.
+   2. Return `400 Bad Request` upon POST request to `/users/register` with an already used username.
+   3. Return `200 OK` and a JWT upon POST to `/users/login` with correct credentials.
+   4. Return `400 Bad Request` upon POST to `/users/login` with incorrect credentials.
+   5. Return `200 OK` upon POST to `/users/reset-password` with the correct security answer.
+   6. Return `400 Bad Request` upon POST to `/users/reset-password` with the incorrect security answer.
+   7. Return `400 Bad Request` upon POST to `/users/reset-password` with a missing payload.
+   8. Return `200 OK` upon PUT to `/users` with valid new user data.
+   9. Return `400 Bad Request` upon PUT to `/users` with a new username that already exists.
+   10. Return `200 OK` upon DELETE to `/users` from authenticated session.
 2. Expense Entry and History
    1. Return `201 Created` upon PUT to `/expenses` with a valid new expense.
    2. Return `200 OK` upon DELETE to `/expenses/:id` with valid expense ID.
@@ -105,9 +105,9 @@ This test plan covers unit, integration, acceptance, regression, and load testin
 
 ### Integration Tests
 
-1. After creating a new user with a POST request to `/auth/register`, the new user data is found in the database with the hashed security answer and password.
-2. After a client obtains JWT from signing in via POST to `/auth/login`, the JWT can be used to make request to an authorized route.
-3. After a client sends the correct security answer via POST to `/auth/reset-password`, their password is successfully hashed and updated in the database.
+1. After creating a new user with a POST request to `/users/register`, the new user data is found in the database with the hashed security answer and password.
+2. After a client obtains JWT from signing in via POST to `/users/login`, the JWT can be used to make request to an authorized route.
+3. After a client sends the correct security answer via POST to `/users/reset-password`, their password is successfully hashed and updated in the database.
 4. After a client sends new user data via POST to `/account/`, their new user data is updated in the database.
 5. After an expense is created via POST to `/expenses`, the user can then fetch the expense they just created via GET to `/expenses/:id`.
 6. After an expense is deleted via POST to `/expenses/:id`, the expense no longer exists in the database, and they can no longer fetch the expense they just deleted via GET to `/expenses/:id`.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,6 @@ app.use(cors());
 app.use(express.json());
 
 // Routes
-app.use('/', userRoutes);
+app.use('/users', userRoutes);
 
 export default app;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -12,7 +12,7 @@ const router = express.Router();
 /**
  * Register a new user
  *
- * @route POST /api/auth/register
+ * @route POST /users/register
  * @group auth - Operations about authentication
  * @param {string} username.body.required - Username
  * @param {string} password.body.required - Password
@@ -82,7 +82,7 @@ router.post(
  *
  * This route will return a JWT that can be used to authenticate the user.
  *
- * @route POST /api/auth/login
+ * @route POST /users/login
  * @group auth - Operations about authentication
  * @param {string} username.body.required - Username
  * @param {string} password.body.required - Password
@@ -141,7 +141,7 @@ router.post(
  *
  * This route will reset a user's password if the security answer is correct.
  *
- * @route POST /api/auth/reset-password
+ * @route POST /users/reset-password
  * @group auth - Operations about authentication
  * @param {string} username.body.required - Username
  * @param {string} securityAnswer.body.required - Security Answer
@@ -211,7 +211,7 @@ router.post(
  * This route will update a user's username, password, security question, and security answer.
  * The user must be authenticated to make this request.
  *
- * @route POST /api/auth/update-user
+ * @route POST /users/update-user
  * @group auth - Operations about authentication
  * @param {string} username.body.required - Username
  * @param {string} password.body.required - Password

--- a/server/src/test/unit/routes/auth.test.ts
+++ b/server/src/test/unit/routes/auth.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../../middleware/authenticate', () => ({
   },
 }));
 
-describe('POST /register', () => {
+describe('POST /users/register', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -29,7 +29,7 @@ describe('POST /register', () => {
 
     prismaMock.user.create.mockResolvedValue(user);
 
-    const response = await request(app).post('/register').send({
+    const response = await request(app).post('/users/register').send({
       username: 'testuser1',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -50,7 +50,7 @@ describe('POST /register', () => {
       securityAnswer: 'Red',
     });
 
-    const response = await request(app).post('/register').send({
+    const response = await request(app).post('/users/register').send({
       username: 'testuser2',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -62,7 +62,7 @@ describe('POST /register', () => {
   });
 
   it('should return 400 if any required field is missing', async () => {
-    const response = await request(app).post('/register').send({
+    const response = await request(app).post('/users/register').send({
       username: 'testuser3',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -75,7 +75,7 @@ describe('POST /register', () => {
   it('should return 500 if user fails to be created', async () => {
     prismaMock.user.create.mockRejectedValue(new Error()); // Mocking database error
 
-    const response = await request(app).post('/register').send({
+    const response = await request(app).post('/users/register').send({
       username: 'testuser3',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -87,9 +87,9 @@ describe('POST /register', () => {
   });
 });
 
-describe('POST /login', () => {
+describe('POST /users/login', () => {
   it('should return 400 if the validation fails', async () => {
-    const response = await request(app).post('/login').send({
+    const response = await request(app).post('/users/login').send({
       username: 'testUser',
       password: 12345678, // Invalid password type (number instead of string)
     });
@@ -101,7 +101,7 @@ describe('POST /login', () => {
   it('should return 400 if username does not exist', async () => {
     prismaMock.user.findUnique.mockResolvedValue(null); // Mocking no user found
 
-    const response = await request(app).post('/login').send({
+    const response = await request(app).post('/users/login').send({
       username: 'wrongUsername',
       password: 'testPassword',
     });
@@ -120,7 +120,7 @@ describe('POST /login', () => {
       securityAnswer: 'Blue',
     });
 
-    const response = await request(app).post('/login').send({
+    const response = await request(app).post('/users/login').send({
       username: 'testUser',
       password: 'wrongPassword',
     });
@@ -141,7 +141,7 @@ describe('POST /login', () => {
       securityAnswer: hashedSecurityAnswer,
     });
 
-    const response = await request(app).post('/login').send({
+    const response = await request(app).post('/users/login').send({
       username: 'testUser',
       password: password,
     });
@@ -153,7 +153,7 @@ describe('POST /login', () => {
   it('should return 500 if there is a server error', async () => {
     prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
 
-    const response = await request(app).post('/login').send({
+    const response = await request(app).post('/users/login').send({
       username: 'testUser',
       password: 'testPassword',
     });
@@ -163,9 +163,9 @@ describe('POST /login', () => {
   });
 });
 
-describe('/reset-password', () => {
+describe('/users/reset-password', () => {
   it('returns 400 for validation errors', async () => {
-    const response = await request(app).post('/reset-password').send({
+    const response = await request(app).post('/users/reset-password').send({
       username: 123, // invalid username for testing
       securityAnswer: 'testAnswer',
       newPassword: 'newPassword',
@@ -178,7 +178,7 @@ describe('/reset-password', () => {
   it('returns 400 if user not found', async () => {
     prismaMock.user.findUnique.mockResolvedValue(null); // Mocking no user found
 
-    const response = await request(app).post('/reset-password').send({
+    const response = await request(app).post('/users/reset-password').send({
       username: 'testUser',
       securityAnswer: 'testAnswer',
       newPassword: 'newPassword',
@@ -198,7 +198,7 @@ describe('/reset-password', () => {
       securityAnswer: hashedAnswer,
     });
 
-    const response = await request(app).post('/reset-password').send({
+    const response = await request(app).post('/users/reset-password').send({
       username: 'testUser',
       securityAnswer: 'wrongAnswer',
       newPassword: 'newPassword',
@@ -219,7 +219,7 @@ describe('/reset-password', () => {
       securityAnswer: hashedAnswer,
     });
 
-    const response = await request(app).post('/reset-password').send({
+    const response = await request(app).post('/users/reset-password').send({
       username: 'testUser',
       securityAnswer: correctAnswer,
       newPassword: 'newPassword',
@@ -232,7 +232,7 @@ describe('/reset-password', () => {
   it('returns 500 if there is a server error', async () => {
     prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
 
-    const response = await request(app).post('/reset-password').send({
+    const response = await request(app).post('/users/reset-password').send({
       username: 'testUser',
       securityAnswer: 'testAnswer',
       newPassword: 'newPassword',
@@ -243,13 +243,13 @@ describe('/reset-password', () => {
   });
 });
 
-describe('POST /update-user', () => {
+describe('POST /users/update-user', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns 400 for validation errors', async () => {
-    const response = await request(app).post('/update-user').send({
+    const response = await request(app).post('/users/update-user').send({
       username: 123, // not a string
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -264,7 +264,7 @@ describe('POST /update-user', () => {
     // Mocking the user check based on ID
     prismaMock.user.findUnique.mockResolvedValueOnce(null);
 
-    const response = await request(app).post('/update-user').send({
+    const response = await request(app).post('/users/update-user').send({
       username: 'testuser',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -293,7 +293,7 @@ describe('POST /update-user', () => {
       securityAnswer: 'OldBlue',
     }); // Indicates new username doesn't exist
 
-    const response = await request(app).post('/update-user').send({
+    const response = await request(app).post('/users/update-user').send({
       username: 'testuser',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -324,7 +324,7 @@ describe('POST /update-user', () => {
       securityAnswer: 'Blue',
     });
 
-    const response = await request(app).post('/update-user').send({
+    const response = await request(app).post('/users/update-user').send({
       username: 'testuser',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',
@@ -337,7 +337,7 @@ describe('POST /update-user', () => {
   it('returns 500 when there is a server error', async () => {
     prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
 
-    const response = await request(app).post('/update-user').send({
+    const response = await request(app).post('/users/update-user').send({
       username: 'testuser',
       password: 'testpassword',
       securityQuestion: 'Your favorite color?',


### PR DESCRIPTION
`/api` prefix is redundant, since the URL of the frontend and backend are different. 
Added `/users` prefix to auth API

Some minor style changes in the test plan, too (I guess MD formatter didn't fix them before)