### PR TITLE
API endpoint for deleting accounts

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -287,25 +287,18 @@ router.post(
 );
 
 router.delete(
-  '/delete-account',
+  '/delete',
   authenticate,
   async (req: Request, res: Response) => {
     try {
       // Get user from token
       const userId = req.userId;
 
-      // Verify that the user that made the request exists
-      const user = await prisma.user.findUnique({
+      // Update user to be deleted
+      // If the user does not exist, this will throw an error
+      const updatedUser = await prisma.user.update({
         where: { id: userId },
-      });
-
-      if (!user) {
-        return res.status(400).json({ message: 'Invalid credentials' });
-      }
-
-      // Delete user from database
-      await prisma.user.delete({
-        where: { id: userId },
+        data: { userDeleted: true },
       });
 
       res.status(200).json({ message: 'User successfully deleted' });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -286,4 +286,33 @@ router.post(
   },
 );
 
+router.delete(
+  '/delete-account',
+  authenticate,
+  async (req: Request, res: Response) => {
+    try {
+      // Get user from token
+      const userId = req.userId;
+
+      // Verify that the user that made the request exists
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+      });
+
+      if (!user) {
+        return res.status(400).json({ message: 'Invalid credentials' });
+      }
+
+      // Delete user from database
+      await prisma.user.delete({
+        where: { id: userId },
+      });
+
+      res.status(200).json({ message: 'User successfully deleted' });
+    } catch (error: unknown) {
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
+
 export default router;

--- a/server/src/test/unit/routes/auth.test.ts
+++ b/server/src/test/unit/routes/auth.test.ts
@@ -359,52 +359,35 @@ describe('POST /users/update-user', () => {
   });
 });
 
-describe('DELETE /users/delete-account', () => {
+describe('DELETE /users/delete', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('returns 400 if user does not exist', async () => {
-    // Mocking the user check based on ID
-    prismaMock.user.findUnique.mockResolvedValueOnce(null);
-
-    const response = await request(app)
-      .delete('/users/delete-account')
-      .send({});
-
-    expect(response.status).toBe(400);
-  });
-
   it('returns 200 if user is deleted', async () => {
-    prismaMock.user.findUnique.mockResolvedValueOnce({
+    prismaMock.user.update.mockResolvedValueOnce({
       id: 1,
       username: 'testuser',
       password: 'testpassword',
       securityQuestion: 'Your old favorite color?',
       securityAnswer: 'Blue',
-    });
-
-    prismaMock.user.delete.mockResolvedValueOnce({
-      id: 1,
-      username: 'testuser',
-      password: 'testpassword',
-      securityQuestion: 'Your old favorite color?',
-      securityAnswer: 'Blue',
+      userDeleted: true,
     });
 
     const response = await request(app)
-      .delete('/users/delete-account')
-      .send({});
+      .delete('/users/delete')
+      .send();
 
     expect(response.status).toBe(200);
+    expect(response.body.message).toBe('User successfully deleted');
   });
 
   it('returns 500 when there is a server error', async () => {
-    prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
+    prismaMock.user.update.mockRejectedValue(new Error());
 
     const response = await request(app)
-      .delete('/users/delete-account')
-      .send({});
+      .delete('/users/delete')
+      .send();
 
     expect(response.status).toBe(500);
     expect(response.body.message).toBe('Server error');

--- a/server/src/test/unit/routes/auth.test.ts
+++ b/server/src/test/unit/routes/auth.test.ts
@@ -358,3 +358,55 @@ describe('POST /users/update-user', () => {
     expect(response.body.message).toBe('Server error');
   });
 });
+
+describe('DELETE /users/delete-account', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 if user does not exist', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app)
+      .delete('/users/delete-account')
+      .send({});
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 200 if user is deleted', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 1,
+      username: 'testuser',
+      password: 'testpassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'Blue',
+    });
+
+    prismaMock.user.delete.mockResolvedValueOnce({
+      id: 1,
+      username: 'testuser',
+      password: 'testpassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'Blue',
+    });
+
+    const response = await request(app)
+      .delete('/users/delete-account')
+      .send({});
+
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 500 when there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
+
+    const response = await request(app)
+      .delete('/users/delete-account')
+      .send({});
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});


### PR DESCRIPTION


Added DELETE `/users/delete` endpoint to allow users to delete their accounts when they are signed in.

This does a **soft delete** by just setting `userDeleted` to `true`. All other data stays the same. So group expenses with the deleted user won't look any different to other users.

Code coverage report:
```
dlarocque@Daniels-MBP server % npx jest --collect-coverage
 PASS  src/test/unit/middleware/authenticate.test.ts
 PASS  src/test/unit/routes/auth.test.ts
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |     100 |      100 |     100 |     100 |                   
 src              |     100 |      100 |     100 |     100 |                   
  app.ts          |     100 |      100 |     100 |     100 |                   
 src/middleware   |     100 |      100 |     100 |     100 |                   
  authenticate.ts |     100 |      100 |     100 |     100 |                   
 src/routes       |     100 |      100 |     100 |     100 |                   
  auth.ts         |     100 |      100 |     100 |     100 |                   
------------------|---------|----------|---------|---------|-------------------

Test Suites: 2 passed, 2 total
Tests:       27 passed, 27 total
Snapshots:   0 total
Time:        2.713 s, estimated 3 s
Ran all test suites.
```

Closes #19 