### PR TITLE
Authentication bypass when in development

### DIFF
--- a/server/src/middleware/authenticate.ts
+++ b/server/src/middleware/authenticate.ts
@@ -20,6 +20,12 @@ export const authenticate = (
   res: Response,
   next: NextFunction,
 ) => {
+  // Bypass authentication in development environment
+  if (process.env.NODE_ENV === 'development') {
+    req.userId = 1;
+    return next();
+  }
+
   const token = req.header('Authorization')?.replace('Bearer ', '');
 
   if (!token) {

--- a/server/src/test/unit/middleware/authenticate.test.ts
+++ b/server/src/test/unit/middleware/authenticate.test.ts
@@ -73,6 +73,25 @@ describe('authenticate middleware', () => {
     expect(req.userId).toBe(userId);
     expect(next).toHaveBeenCalled();
   });
+
+  it('sets userId to 1 in development environment', () => {
+    // Store the original NODE_ENV
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    // Override NODE_ENV for this test
+    process.env.NODE_ENV = 'development';
+
+    authenticate(req as Request, res as Response, next);
+
+    // Check that userId is set to 1
+    expect(req.userId).toBe(1);
+
+    // Check that the next function has been called
+    expect(next).toHaveBeenCalled();
+
+    // Restore the original NODE_ENV
+    process.env.NODE_ENV = originalNodeEnv;
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
It's annoying to have to manually register, login, get the token and attach it to headers when you're making requests when testing endpoints, so now we can just set `NODE_ENV='development` in `server/.env` to bypass this.

**Note**: The server will *assume* that `userId=1`.  

I added tests so that we're still at 100% code coverage.