### PR TITLE
Added seperate endpoints for updating username and password

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -290,6 +290,18 @@ router.post(
   },
 );
 
+/**
+ * Update a user's username
+ *
+ * This route will update a user's username.
+ *
+ * @route POST /users/update-username
+ * @group auth - Operations about authentication
+ * @param {string} username.body.required - Username
+ * @returns {object} 200 - Username successfully updated
+ * @returns {Error}  400 - Invalid credentials
+ * @returns {Error}  500 - Server error
+ */
 router.post(
   '/update-username',
   authenticate,
@@ -337,6 +349,18 @@ router.post(
   },
 );
 
+/**
+ * Update a user's password
+ *
+ * This route will update a user's password.
+ *
+ * @route POST /users/update-password
+ * @group auth - Operations about authentication
+ * @param {string} password.body.required - Password
+ * @returns {object} 200 - Password successfully updated
+ * @returns {Error}  400 - Invalid credentials
+ * @returns {Error}  500 - Server error
+ */
 router.post(
   '/update-password',
   authenticate,

--- a/server/src/test/unit/routes/auth.test.ts
+++ b/server/src/test/unit/routes/auth.test.ts
@@ -359,6 +359,166 @@ describe('POST /users/update-user', () => {
   });
 });
 
+describe('POST /users/update-username', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 for validation errors', async () => {
+    const response = await request(app).post('/users/update-username').send({
+      // missing username
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toBeDefined();
+  });
+
+  it('returns 400 if user does not exist', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app).post('/users/update-username').send({
+      username: 'newUsername',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 if new username already exists', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 1,
+      username: 'oldUsername',
+      password: 'oldpassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'OldBlue',
+      userDeleted: false,
+    });
+
+    // Mocking the user check based on new username
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 1,
+      username: 'existingUsername',
+      password: 'existingPassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'OldBlue',
+      userDeleted: false,
+    });
+
+    const response = await request(app).post('/users/update-username').send({
+      username: 'existingUsername',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('Username already exists');
+  });
+
+  it('returns 200 if username is updated', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 1,
+      username: 'oldUsername',
+      password: 'oldPassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'OldBlue',
+      userDeleted: false,
+    });
+
+    // Mocking the user check based on new username
+    prismaMock.user.findUnique.mockResolvedValueOnce(null); // Indicates new username doesn't exist
+
+    prismaMock.user.update.mockResolvedValue({
+      id: 1,
+      username: 'newUsername',
+      password: 'testpassword',
+      securityQuestion: 'Your favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: false,
+    });
+
+    const response = await request(app).post('/users/update-username').send({
+      username: 'newUsername',
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 500 when there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
+
+    const response = await request(app).post('/users/update-username').send({
+      username: 'newUsername',
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});
+
+describe('POST /users/update-password', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 for validation errors', async () => {
+    const response = await request(app).post('/users/update-password').send({
+      // missing password
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toBeDefined();
+  });
+
+  it('returns 400 if user does not exist', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app).post('/users/update-password').send({
+      password: 'newPassword',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 200 if password is updated', async () => {
+    // Mocking the user check based on ID
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: 1,
+      username: 'testUsername',
+      password: 'oldPassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'OldBlue',
+      userDeleted: false,
+    });
+
+    prismaMock.user.update.mockResolvedValue({
+      id: 1,
+      username: 'testUsername',
+      password: 'newPassword',
+      securityQuestion: 'Your favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: false,
+    });
+
+    const response = await request(app).post('/users/update-password').send({
+      password: 'newPassword',
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 500 when there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error()); // Mocking database error
+
+    const response = await request(app).post('/users/update-password').send({
+      password: 'newPassword',
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});
+
 describe('DELETE /users/delete', () => {
   afterEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
- `POST /users/update-username` updates the username of the user if it's not taken by another user
- `POST /users/update-password` updates the password of the user

Makes updating username and password easier on the client-side.

Added tests, so we're still at 100% code coverage.