### PR TITLE
Fix: The user hide all columns

### DIFF
--- a/client/src/pages/Expenses/Components/ExpenseTable.tsx
+++ b/client/src/pages/Expenses/Components/ExpenseTable.tsx
@@ -115,6 +115,7 @@ export const ExpensesTable: React.FC<ExpenseTableProps> = ({
   return (
     <BackgroundBox>
       <ExpensesDataGrid
+        disableColumnSelector
         rows={expenses}
         columns={columns}
         getRowId={(row) => row.id}


### PR DESCRIPTION
I've disabled the column selector on the expenses so that the users can't hide any column

![image](https://github.com/BarbzCodez/Spendr/assets/93229091/58dbf786-b1cb-44ba-86c7-8e78b8b0e5cc)

Closes #96 