### PR TITLE
Fetch, create group expenses and mark as paid

### DIFF
--- a/server/prisma/migrations/20231103003844_main/migration.sql
+++ b/server/prisma/migrations/20231103003844_main/migration.sql
@@ -1,0 +1,2 @@
+-- DropForeignKey
+ALTER TABLE "GroupExpenseSplit" DROP CONSTRAINT "GroupExpenseSplit_groupExpenseId_fkey";

--- a/server/prisma/migrations/20231104160120_main/migration.sql
+++ b/server/prisma/migrations/20231104160120_main/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "GroupExpenseSplit" ADD CONSTRAINT "GroupExpenseSplit_groupExpenseId_fkey" FOREIGN KEY ("groupExpenseId") REFERENCES "GroupExpense"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -53,7 +53,6 @@ model GroupExpense {
   id          Int                 @id @default(autoincrement())
   title       String
   totalAmount Float
-  members     GroupExpenseSplit[]
   category    ExpenseCategory // Assign category to each group expense
   createdAt   DateTime            @default(now())
 }
@@ -64,7 +63,6 @@ model GroupExpenseSplit {
   userId         Int
   user           User         @relation(fields: [userId], references: [id])
   groupExpenseId Int
-  groupExpense   GroupExpense @relation(fields: [groupExpenseId], references: [id])
   shareAmount    Float
   hasPaid        Boolean      @default(false) //Default payment status is user has not paid
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -50,11 +50,12 @@ model Expense {
 
 // Group expenses (not associated with users)
 model GroupExpense {
-  id          Int                 @id @default(autoincrement())
-  title       String
-  totalAmount Float
-  category    ExpenseCategory // Assign category to each group expense
-  createdAt   DateTime            @default(now())
+  id                Int                 @id @default(autoincrement())
+  title             String
+  totalAmount       Float
+  category          ExpenseCategory // Assign category to each group expense
+  createdAt         DateTime            @default(now())
+  groupExpenseSplits GroupExpenseSplit[] // Easily query for groupExpenseSplits
 }
 
 // Individual splits of a Group expense (associated with users)
@@ -63,6 +64,7 @@ model GroupExpenseSplit {
   userId         Int
   user           User         @relation(fields: [userId], references: [id])
   groupExpenseId Int
+  groupExpense   GroupExpense @relation(fields: [groupExpenseId], references: [id])
   shareAmount    Float
   hasPaid        Boolean      @default(false) //Default payment status is user has not paid
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import userRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
+import groupExpenseRoutes from './routes/groupExpenses';
 import budgetRoutes from './routes/budgets';
 import { userLog, userErrorLog, sysErrorLog } from './middleware/errorLogging';
 
@@ -18,6 +19,7 @@ app.use(sysErrorLog);
 // Routes
 app.use('/users', userRoutes);
 app.use('/expenses', expenseRoutes);
+app.use('/group-expenses', groupExpenseRoutes);
 app.use('/budgets', budgetRoutes);
 
 export default app;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -522,4 +522,109 @@ router.get(
   },
 );
 
+/**
+ * Get all group expenses for a user
+ *
+ * This route will return all group expenses for a user, including the user's paid status and share amount for each group expense.
+ * The user must be authenticated to make this request.
+ *
+ * @route GET /users/:userId/group-expenses
+ * @group users - Operations about users
+ * @param {string} userId.path.required - User ID
+ * @returns {object} 200 - All group expenses for the user
+ * @returns {Error}  400 - Invalid credentials
+ * @returns {Error}  500 - Server error
+ *
+ * @example response - 200 - All group expenses for the user
+ * {
+ *  "success": true,
+ *  "data": [
+ *      {
+ *          "title": "Group Expense",
+ *          "totalAmount": 40,
+ *          "category": "GROCERIES",
+ *          "createdAt": "2023-10-12T10:20:30.000Z",
+ *          "split": [
+ *              {
+ *                  "userId": 2,
+ *                  "username": "Bob",
+ *                  "hasPaid": false,
+ *                  "shareAmount": 20
+ *              },
+ *              {
+ *                  "userId": 3,
+ *                  "username": "Alice",
+ *                  "hasPaid": false,
+ *                  "shareAmount": 20
+ *              },
+ *          ]
+ *      }
+ *   ]
+ * }
+ */
+router.get(
+  '/:userId/group-expenses',
+  authenticate,
+  async (req: Request, res: Response) => {
+    try {
+      const userId = parseInt(req.params.userId);
+
+      // Make sure the user exists
+      const user = await prisma.user.findUnique({
+        where: {
+          id: userId,
+        },
+      });
+
+      if (!user || user.userDeleted) {
+        return res.status(400).json({ message: 'Invalid Credentials' });
+      }
+
+      // Fetch all the group expenses for the user, and include each user's
+      // paid status and share amount for each group expense.
+      const groupExpensesWithUsers = await prisma.groupExpenseSplit.findMany({
+        where: {
+          userId: userId,
+        },
+        include: {
+          groupExpense: {
+            include: {
+              groupExpenseSplits: {
+                include: {
+                  user: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      // Format the data to be returned
+      const groupExpenses = groupExpensesWithUsers.map((groupExpense) => {
+        const groupExpenseSplits = groupExpense.groupExpense.groupExpenseSplits;
+        const groupExpenseData = {
+          title: groupExpense.groupExpense.title,
+          totalAmount: groupExpense.groupExpense.totalAmount,
+          category: groupExpense.groupExpense.category,
+          createdAt: groupExpense.groupExpense.createdAt,
+          // All users usernames, hasPaid, and shareAmount
+          split: groupExpenseSplits.map((groupExpenseSplit) => ({
+            userId: groupExpenseSplit.userId,
+            username: groupExpenseSplit.user.username,
+            hasPaid: groupExpenseSplit.hasPaid,
+            shareAmount: groupExpenseSplit.shareAmount,
+          })),
+        };
+
+        return groupExpenseData;
+      });
+
+      res.status(200).json({ success: true, data: groupExpenses });
+    } catch (error) {
+      res.locals.error = error;
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
+
 export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -460,8 +460,6 @@ router.get(
         },
       });
 
-      // TODO: Fetch group expenses
-
       // Combine individual and group expenses into one list
       const allExpenses = [...individualExpenses];
 

--- a/server/src/routes/groupExpenses.ts
+++ b/server/src/routes/groupExpenses.ts
@@ -125,6 +125,20 @@ router.post(
   },
 );
 
+/**
+ * Mark a group expense as paid
+ *
+ * This route marks a group expense as paid for the authenticated user.
+ * The user must be part of the group expense.
+ * Once the group expense is marked as paid, a new expense is created for the user.
+ *
+ * @route PUT /group-expenses/:groupExpenseId/mark-as-paid
+ * @param groupExpenseId ID of the group expense
+ * @returns {object} An object containing the newly created group expense
+ * @throws {object} 401 - If the user is not authenticated
+ * @throws {object} 404 - If the group expense is not found
+ * @throws {object} 500 - If there is a server error
+ */
 router.put(
   '/:groupExpenseId/mark-as-paid',
   authenticate,

--- a/server/src/routes/groupExpenses.ts
+++ b/server/src/routes/groupExpenses.ts
@@ -19,7 +19,7 @@ const router = express.Router();
  * @param amount Amount of the group expense
  * @param category Category of the group expense
  * @param createdAt Date the group expense was created
- * @param usernames Usernames of the users that are part of the group expense
+ * @param split Object containing the percent split shares for each user (e.g. {"user1": 0.5, "user2": 0.5})
  * @returns {object} An object containing the newly created group expense
  * @throws {object} 400 - If the request body is invalid
  * @throws {object} 401 - If the user is not authenticated
@@ -126,7 +126,7 @@ router.post(
 );
 
 /**
- * Mark a group expense as paid
+ * Mark a group expense as paid for the authenticated user
  *
  * This route marks a group expense as paid for the authenticated user.
  * The user must be part of the group expense.

--- a/server/src/routes/groupExpenses.ts
+++ b/server/src/routes/groupExpenses.ts
@@ -1,0 +1,199 @@
+import express, { Request, Response } from 'express';
+import prisma from '../prismaClient';
+import { body, validationResult } from 'express-validator';
+import { authenticate } from '../middleware/authenticate';
+import dotenv from 'dotenv';
+import { ExpenseCategory } from '@prisma/client';
+
+dotenv.config();
+
+const router = express.Router();
+
+/**
+ * Create a new group expense
+ *
+ * This route creates a new group expense for the authenticated user.
+ *
+ * @route POST /group-expenses
+ * @param title Title of the group expense
+ * @param amount Amount of the group expense
+ * @param category Category of the group expense
+ * @param createdAt Date the group expense was created
+ * @param usernames Usernames of the users that are part of the group expense
+ * @returns {object} An object containing the newly created group expense
+ * @throws {object} 400 - If the request body is invalid
+ * @throws {object} 401 - If the user is not authenticated
+ * @throws {object} 500 - If there is a server error
+ */
+router.post(
+  '/',
+  authenticate,
+  body('title').isString().withMessage('Title must be a string'),
+  body('amount').isFloat().withMessage('Amount must be a number'),
+  body('createdAt')
+    .isISO8601()
+    .withMessage('createdAt must be a valid date in ISO 8601 format.'),
+  body('category')
+    .isString()
+    .isIn(Object.values(ExpenseCategory))
+    .withMessage('Category must be a valid category'),
+  body('split').isObject().withMessage('Split must be an object'),
+  body('split.*')
+    .isDecimal()
+    .withMessage('Each split value must be a decimal number'),
+  body('split').custom((split: Record<string, number>) => {
+    const totalShare = Object.values(split).reduce(
+      (sum, share) => sum + share,
+      0,
+    );
+    const EPSILON = 0.0001;
+    if (Math.abs(totalShare - 1) > EPSILON) {
+      throw new Error(
+        'Split shares must add up to 1 within a small margin of error',
+      );
+    }
+    return true;
+  }),
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    try {
+      const { title, amount, createdAt, category, split } = req.body;
+      const usernames = Object.keys(split);
+
+      // Verify that the user that made the request exists
+      const user = await prisma.user.findUnique({
+        where: { id: req.userId },
+      });
+
+      if (!user || user.userDeleted) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
+
+      // Verify users exist
+      const users = await prisma.user.findMany({
+        where: { username: { in: usernames } },
+      });
+
+      if (users.length !== usernames.length) {
+        return res.status(400).json({
+          message: "Invalid usernames, at least one of the users doesn't exist",
+        });
+      }
+
+      // Verify that none of the users were deleted
+      const deletedUsers = users.filter((user) => user.userDeleted);
+      if (deletedUsers.length > 0) {
+        return res.status(400).json({
+          message: "Invalid usernames, at least one of the users doesn't exist",
+        });
+      }
+
+      // Create the group expense
+      const groupExpense = await prisma.groupExpense.create({
+        data: {
+          title,
+          totalAmount: amount,
+          createdAt,
+          category,
+        },
+      });
+
+      // Create the group expense splits
+      for (const user of users) {
+        await prisma.groupExpenseSplit.create({
+          data: {
+            userId: user.id,
+            groupExpenseId: groupExpense.id,
+            shareAmount: split[user.username] * amount,
+            hasPaid: false,
+          },
+        });
+      }
+
+      res.status(201).json({
+        message: 'Group expense successfully created',
+        groupExpense,
+      });
+    } catch (error) {
+      res.locals.error = error;
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
+
+router.put(
+  '/:groupExpenseId/mark-as-paid',
+  authenticate,
+  async (req: Request, res: Response) => {
+    try {
+      const { userId } = req;
+      const { groupExpenseId } = req.params;
+
+      // Verify that the user that made the request exists
+      const user = await prisma.user.findUnique({
+        where: { id: req.userId },
+      });
+
+      if (!user || user.userDeleted) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
+
+      // Get the group expense split with the userId and groupExpenseId
+      const groupExpenseSplit = await prisma.groupExpenseSplit.findFirst({
+        where: {
+          userId: userId,
+          groupExpenseId: parseInt(groupExpenseId),
+        },
+      });
+
+      if (!groupExpenseSplit) {
+        return res.status(404).json({ message: 'Group expense not found' });
+      }
+
+      // Get the group expense
+      const groupExpense = await prisma.groupExpense.findUnique({
+        where: {
+          id: groupExpenseSplit.groupExpenseId,
+        },
+      });
+
+      if (!groupExpense) {
+        return res.status(404).json({ message: 'Group expense not found' });
+      }
+
+      // Mark the group expense split as paid
+      await prisma.groupExpenseSplit.update({
+        where: {
+          id: groupExpenseSplit.id,
+        },
+        data: {
+          hasPaid: true,
+        },
+      });
+
+      // Create a new expense for the user
+      await prisma.expense.create({
+        data: {
+          userId: userId,
+          title: groupExpense.title,
+          amount: groupExpenseSplit.shareAmount,
+          category: groupExpense.category,
+          createdAt: groupExpense.createdAt,
+        },
+      });
+
+      res.status(201).json({
+        message: 'Group expense successfully marked as paid',
+      });
+    } catch (error) {
+      res.locals.error = error;
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
+
+export default router;

--- a/server/src/test/unit/routes/groupExpenses.test.ts
+++ b/server/src/test/unit/routes/groupExpenses.test.ts
@@ -1,0 +1,366 @@
+import request from 'supertest';
+import { Request, Response, NextFunction } from 'express';
+import app from '../../../app';
+import { prismaMock } from '../../../singleton';
+import { ExpenseCategory } from '@prisma/client';
+
+const firstUser = {
+  id: 1,
+  username: 'testuser',
+  password: 'testpassword',
+  securityQuestion: 'Your old favorite color?',
+  securityAnswer: 'Blue',
+  userDeleted: false,
+};
+const secondUser = {
+  id: 2,
+  username: 'testuser2',
+  password: 'testpassword',
+  securityQuestion: 'Your old favorite color?',
+  securityAnswer: 'Blue',
+  userDeleted: false,
+};
+
+jest.mock('../../../middleware/authenticate', () => ({
+  authenticate: (req: Request, res: Response, next: NextFunction) => {
+    req.userId = 1;
+    next();
+  },
+}));
+
+describe('POST /group-expenses', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 201 if the request is valid', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.user.findMany.mockResolvedValue([firstUser, secondUser]);
+    prismaMock.groupExpense.create.mockResolvedValue({
+      id: 1,
+      title: 'Test Group Expense',
+      totalAmount: 100,
+      category: ExpenseCategory.GROCERIES,
+      createdAt: new Date('2023-10-12T10:20:30Z'),
+    });
+    prismaMock.groupExpenseSplit.create.mockResolvedValueOnce({
+      id: 1,
+      userId: 1,
+      groupExpenseId: 1,
+      shareAmount: 50,
+      hasPaid: false,
+    });
+    prismaMock.groupExpenseSplit.create.mockResolvedValueOnce({
+      id: 2,
+      userId: 2,
+      groupExpenseId: 1,
+      shareAmount: 50,
+      hasPaid: false,
+    });
+
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      message: 'Group expense successfully created',
+      groupExpense: {
+        id: 1,
+        title: 'Test Group Expense',
+        totalAmount: 100,
+        category: ExpenseCategory.GROCERIES,
+        createdAt: '2023-10-12T10:20:30.000Z',
+      },
+    });
+  });
+
+  it('should return 400 if the title is invalid', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 1234,
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the amount is invalid', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: '100x',
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the category is invalid', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'TEST',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the createdAt is invalid', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '03/13/2013',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the split has the invalid format', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 'zero' },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the split does not sum to 1', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.6 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if the split is close to 1', async () => {
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.499, testuser2: 0.499 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 401 if the user was not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 400 if one of the users was deleted', async () => {
+    const deletedUser = {
+      id: 2,
+      username: 'deletedUser',
+      password: 'testpassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: true,
+    };
+
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.user.findMany.mockResolvedValue([firstUser, deletedUser]);
+
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, deletedUser: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 if one of the users does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.user.findMany.mockResolvedValue([firstUser]);
+
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 500 if there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValueOnce(new Error());
+
+    const response = await request(app)
+      .post('/group-expenses')
+      .send({
+        title: 'Test Group Expense',
+        amount: 100,
+        category: 'GROCERIES',
+        createdAt: '2023-10-12T10:20:30Z',
+        split: { testuser: 0.5, testuser2: 0.5 },
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});
+
+describe('PUT /group-expenses/:groupExpenseId/mark-as-paid', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 if the request is valid', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.groupExpenseSplit.findFirst.mockResolvedValue({
+      id: 1,
+      userId: 1,
+      groupExpenseId: 1,
+      shareAmount: 50,
+      hasPaid: false,
+    });
+
+    prismaMock.groupExpense.findUnique.mockResolvedValue({
+      id: 1,
+      title: 'Test Group Expense',
+      totalAmount: 100,
+      category: ExpenseCategory.GROCERIES,
+      createdAt: new Date('2023-10-12T10:20:30Z'),
+    });
+
+    prismaMock.groupExpenseSplit.update.mockResolvedValue({
+      id: 1,
+      userId: 1,
+      groupExpenseId: 1,
+      shareAmount: 50,
+      hasPaid: true,
+    });
+
+    prismaMock.expense.create({
+      data: {
+        userId: 1,
+        title: 'Test Group Expense',
+        amount: 100,
+        category: ExpenseCategory.GROCERIES,
+        createdAt: new Date('2023-10-12T10:20:30Z'),
+      },
+    });
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      message: 'Group expense successfully marked as paid',
+    });
+  });
+
+  it('should return 401 if the user was not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 401 if the user was deleted', async () => {
+    const deletedUser = {
+      id: 1,
+      username: 'testuser',
+      password: 'testpassword',
+      securityQuestion: 'Your old favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: true,
+    };
+
+    prismaMock.user.findUnique.mockResolvedValueOnce(deletedUser);
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 404 if the group expense split was not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.groupExpenseSplit.findFirst.mockResolvedValue(null);
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 404 if the group expense was not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(firstUser);
+    prismaMock.groupExpenseSplit.findFirst.mockResolvedValue({
+      id: 1,
+      userId: 1,
+      groupExpenseId: 1,
+      shareAmount: 50,
+      hasPaid: false,
+    });
+    prismaMock.groupExpense.findUnique.mockResolvedValue(null);
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 500 if there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValueOnce(new Error());
+
+    const response = await request(app).put('/group-expenses/1/mark-as-paid');
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});

--- a/server/src/utils/expenses.ts
+++ b/server/src/utils/expenses.ts
@@ -49,7 +49,6 @@ async function calculateTotalExpenseForBudget(budget: Budget): Promise<number> {
   }
 
   // Fetch expenses for the budget and return the total amount
-  // TODO: Fetch group expenses
   const expenses = await prisma.expense.findMany({ where: whereClause });
   return expenses.reduce((acc, expense) => acc + expense.amount, 0);
 }


### PR DESCRIPTION
- `POST /group-expenses`
- `PUT /group-expenses/:groupExpenseId/mark-as-paid`
- Dropped `members` field in GroupExpense model, since it was a circular dependency that was causing issues

When a group expense is marked as paid, a new expense is greated with the title and category of the group expense.

Closes #80 
Closes #40 
Closes #120 

Code coverage report:
```
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |
 src               |     100 |      100 |     100 |     100 |
  app.ts           |     100 |      100 |     100 |     100 |
 src/middleware    |     100 |      100 |     100 |     100 |
  authenticate.ts  |     100 |      100 |     100 |     100 |
  errorLogging.ts  |     100 |      100 |     100 |     100 |
 src/routes        |     100 |      100 |     100 |     100 |
  auth.ts          |     100 |      100 |     100 |     100 |
  budgets.ts       |     100 |      100 |     100 |     100 |
  expenses.ts      |     100 |      100 |     100 |     100 |
  groupExpenses.ts |     100 |      100 |     100 |     100 |
 src/utils         |     100 |      100 |     100 |     100 |
  expenses.ts      |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------
Test Suites: 5 passed, 5 total
Tests:       81 passed, 81 total
Snapshots:   0 total
Time:        8.685 s, estimated 10 s
Ran all test suites.
```