### PR TITLE
Return 400 on validation errors when updating expense

### DIFF
--- a/server/src/routes/expenses.ts
+++ b/server/src/routes/expenses.ts
@@ -120,6 +120,11 @@ router.put(
     .isIn(Object.values(ExpenseCategory))
     .withMessage('Category must be a valid category'),
   async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
     const { expenseId } = req.params;
 
     try {

--- a/server/src/test/unit/routes/expenses.test.ts
+++ b/server/src/test/unit/routes/expenses.test.ts
@@ -173,6 +173,17 @@ describe('PUT /expenses/:expenseId', () => {
     expect(response.status).toBe(200);
   });
 
+  it('should return 400 if the title is invalid', async () => {
+    const response = await request(app).put('/expenses/1').send({
+      title: 1234,
+      amount: 100,
+      createdAt: '2023-10-12T10:20:30Z',
+      category: 'GROCERIES',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it('should return 404 is the expense is not found', async () => {
     prismaMock.expense.findUnique.mockResolvedValue(null);
 


### PR DESCRIPTION
If one of the request body values to `PUT /expenses/:expenseId` is invalid, return a 400 with validation errors.