### PR TITLE
Get total expense gategory

### DIFF
--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -729,7 +729,7 @@ router.get(
  * @param {string} startDate start date for the query (ISO8601 format)
  * @param {string} endDate end date of the query (ISO8601 format)
  * @throws {object} 500 - If there is a server error
- * @returns {object} An object containing the category totals as seen below
+ * @returns {object} 200 - An object containing the category totals as seen below
  *
  *  [
  *    {

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -787,7 +787,7 @@ router.get(
       }[] = [];
 
       userExpenses.forEach((expense) => {
-        //Check for expense category
+        // Check for expense category
         const obj = expensesTotalByCategory.find(
           (obj) => obj.category == expense.category,
         );

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -720,25 +720,25 @@ router.get(
 );
 
 /**
- * Get total for all categories
+ * Get total expenses for all categories given a timeframe
  *
  * This router returns the total amount spent for all categories
  *
  * @route GET /expenses/total-spending-for-categories
  * @param {string} userId.path.required - User ID
- * @param startDate start date for the query (ISO8601 format)
- * @param endDate end date of the query (ISO8601 format)
+ * @param {string} startDate start date for the query (ISO8601 format)
+ * @param {string} endDate end date of the query (ISO8601 format)
  * @throws {object} 500 - If there is a server error
  * @returns {object} An object containing the category totals as seen below
  *
  *  [
  *    {
- *       "category":"GROCERIES",
- *       "amount": 500.00
+ *       category: "GROCERIES",
+ *       amount: 500.00
  *    },
  *    {
- *       "category":"TRANSPORT",
- *       "amount": 200.00
+ *       category: "TRANSPORT",
+ *       amount: 200.00
  *    }
  *  ]
  */

--- a/server/src/test/unit/routes/users.test.ts
+++ b/server/src/test/unit/routes/users.test.ts
@@ -967,3 +967,137 @@ describe('GET /users/:userId/expenses/total-daily', () => {
     expect(response.body.message).toBe('Server error');
   });
 });
+
+describe('GET /users/:userId/expenses/total-spending-for-categories', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 with category and total if expenses are found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 1,
+      username: 'testuser',
+      password: 'testpassword',
+      securityQuestion: 'Your favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: false,
+    });
+
+    const mockedExpenses = [
+      {
+        id: 1,
+        userId: 1,
+        title: 'expense 1',
+        amount: 100,
+        createdAt: new Date('2023-10-12T00:20:00Z'),
+        category: ExpenseCategory.GROCERIES,
+      },
+      {
+        id: 2,
+        userId: 1,
+        title: 'expense 2',
+        amount: 100,
+        createdAt: new Date('2023-10-12T00:00:00Z'),
+        category: ExpenseCategory.GROCERIES,
+      },
+      {
+        id: 3,
+        userId: 1,
+        title: 'expense 3',
+        amount: 100,
+        createdAt: new Date('2023-10-13T00:00:00Z'),
+        category: ExpenseCategory.GROCERIES,
+      },
+      {
+        id: 4,
+        userId: 1,
+        title: 'expense 4',
+        amount: 200,
+        createdAt: new Date('2023-10-13T00:00:00Z'),
+        category: ExpenseCategory.HEALTH,
+      },
+    ];
+
+    prismaMock.expense.findMany.mockResolvedValue(mockedExpenses);
+
+    const response = await request(app)
+      .get('/users/1/expenses/total-spending-for-categories')
+      .send({
+        startDate: '2023-10-12',
+        endDate: '2023-10-14',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual([
+      {
+        category: 'GROCERIES',
+        amount: 300,
+      },
+      {
+        category: 'HEALTH',
+        amount: 200,
+      },
+    ]);
+  });
+
+  it('returns 400 if user does not exist', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null); // Mocking no user
+
+    const response = await request(app)
+      .get('/users/1/expenses/total-spending-for-categories')
+      .send({
+        startDate: '2023-10-12',
+        endDate: '2023-10-14',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('Invalid Credentials');
+  });
+
+  it('returns 400 if user is deleted', async () => {
+    const user = {
+      id: 1,
+      username: 'testuser',
+      password: 'testpassword',
+      securityQuestion: 'Your favorite color?',
+      securityAnswer: 'Blue',
+      userDeleted: true,
+    };
+    prismaMock.user.findUnique.mockResolvedValue(user);
+
+    const response = await request(app)
+      .get('/users/1/expenses/total-spending-for-categories')
+      .send({
+        startDate: '2023-10-12',
+        endDate: '2023-10-14',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('Invalid Credentials');
+  });
+
+  it('returns 400 when there is an error in the input format', async () => {
+    const response = await request(app)
+      .get('/users/1/expenses/total-spending-for-categories')
+      .send({
+        startDate: 'random',
+        endDate: 'string',
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 500 when there is a server error', async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error());
+
+    const response = await request(app)
+      .get('/users/1/expenses/total-spending-for-categories')
+      .send({
+        startDate: '2023-10-12',
+        endDate: '2023-10-14',
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('Server error');
+  });
+});


### PR DESCRIPTION
Added  GET /:userId/expenses/total-spending-for-categories endpoint
100% coverage:
```
 PASS  src/test/unit/middleware/authenticate.test.ts
 PASS  src/test/unit/routes/budgets.test.ts
 PASS  src/test/unit/routes/expenses.test.ts
 PASS  src/test/unit/routes/groupExpenses.test.ts
 PASS  src/test/unit/routes/users.test.ts (7.049 s)
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |
 src               |     100 |      100 |     100 |     100 |
  app.ts           |     100 |      100 |     100 |     100 |
 src/middleware    |     100 |      100 |     100 |     100 |
  authenticate.ts  |     100 |      100 |     100 |     100 |
  errorLogging.ts  |     100 |      100 |     100 |     100 |
 src/routes        |     100 |      100 |     100 |     100 |
  budgets.ts       |     100 |      100 |     100 |     100 |
  expenses.ts      |     100 |      100 |     100 |     100 |
  groupExpenses.ts |     100 |      100 |     100 |     100 |
  users.ts         |     100 |      100 |     100 |     100 |
 src/utils         |     100 |      100 |     100 |     100 |
  expenses.ts      |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------

Test Suites: 5 passed, 5 total
Tests:       103 passed, 103 total
Snapshots:   0 total
Time:        7.682 s
Ran all test suites.
```