### PR TITLE
Percentage change fixed when first average is 0

### DIFF
--- a/client/src/pages/Analytics/components/CompareGraph.tsx
+++ b/client/src/pages/Analytics/components/CompareGraph.tsx
@@ -197,12 +197,17 @@ export const CompareGraph = (): JSX.Element => {
   const getComparisonInfo = () => {
     const firstMonthAvg = Number(getAverage(firstMonthData));
     const secondMonthAvg = Number(getAverage(secondMonthData));
-    const percentageChange =
-      firstMonthAvg == 0 && secondMonthAvg == 0
-        ? '0.00'
-        : Math.abs(
-            ((secondMonthAvg - firstMonthAvg) / firstMonthAvg) * 100,
-          ).toFixed(2);
+    const percentageChange = (() => {
+      if (firstMonthAvg == 0 && secondMonthAvg == 0) {
+        return '0.00';
+      } else if (firstMonthAvg == 0) {
+        return '?';
+      }
+
+      return Math.abs(
+        ((secondMonthAvg - firstMonthAvg) / firstMonthAvg) * 100,
+      ).toFixed(2);
+    })();
     const isDecrease = firstMonthAvg >= secondMonthAvg;
 
     const averageText = (

--- a/client/src/pages/Analytics/components/CompareGraph.tsx
+++ b/client/src/pages/Analytics/components/CompareGraph.tsx
@@ -201,7 +201,7 @@ export const CompareGraph = (): JSX.Element => {
       if (firstMonthAvg == 0 && secondMonthAvg == 0) {
         return '0.00';
       } else if (firstMonthAvg == 0) {
-        return '?';
+        return '-';
       }
 
       return Math.abs(


### PR DESCRIPTION
when first month average is 0, the percentage changed is being calculated by dividing by 0, resulting in 'infinity%'
idk if there's a better way of displaying it so decided to go with ?. let me know if you have better ideas

before:
![image](https://github.com/BarbzCodez/Spendr/assets/93400045/e848886f-cdeb-4927-b85d-abf759bf0e81)

after:
![image](https://github.com/BarbzCodez/Spendr/assets/93400045/44005a24-77aa-41ed-b3bb-bd1485c10247)
