### PR TITLE
Add environment variables to client image build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,9 @@ jobs:
       run: cd client && npm install
 
     - name: Build Client
+      env:
+        REACT_APP_API_URL: http://spendr.pro
+        REACT_APP_EDENAI_API_KEY: ${{ secrets.REACT_APP_EDENAI_API_KEY }}
       run: cd client && npm run build
 
     - name: Upload production ready build files


### PR DESCRIPTION
Client environment variables need to be set at build time for the docker images. So, we need to set the API URL environment variable to spendr.pro when we build.